### PR TITLE
Update use case to exclude base heuristically from radius calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 Today's TTRPG mini figures are too dainty. Make those STL thicker.
 
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/tomwillis608/thicker-stl/main.svg)]
-(<https://results.pre-commit.ci/latest/github/tomwillis608/thicker-stl/main>)
-[![codecov](https://codecov.io/gh/tomwillis608/thicker-stl/graph/badge.svg?token=09Z4F6VAW5)](https://codecov.io/gh/tomwillis608/thicker-stl)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/tomwillis608/thicker-stl/main.svg)](<https://results.pre-commit.ci/latest/github/tomwillis608/thicker-stl/main>)
+[![codecov](https://codecov.io/gh/tomwillis608/thicker-stl/graph/badge.svg?token=09Z4F6VAW5)](<https://codecov.io/gh/tomwillis608/thicker-stl>)
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Today's TTRPG mini figures are too dainty. Make those STL thicker.
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/tomwillis608/thicker-stl/main.svg)]
 (<https://results.pre-commit.ci/latest/github/tomwillis608/thicker-stl/main>)
+[![codecov](https://codecov.io/gh/tomwillis608/thicker-stl/graph/badge.svg?token=09Z4F6VAW5)](https://codecov.io/gh/tomwillis608/thicker-stl)
 
 ## Project Overview
 

--- a/docs/adrs/011-base-height-heuristic.md
+++ b/docs/adrs/011-base-height-heuristic.md
@@ -7,7 +7,9 @@ Accepted
 ## Context
 
 In tabletop figurine models, the actual figure is often mounted on a disc-like base. For transformations like
-thickening, the cylindrical transformation should apply only to the figurine and not the base. Manually requiring
+thickening, the cylindrical transformation should apply only to the figurine and not the base. Including the base in
+height and radius
+calculations leads to inaccurate results for the Hemispherical Cylinder Transformation. Manually requiring
 users to input the height of the base adds complexity to the user interface and could result in errors. Therefore, we
 need a heuristic to estimate the base height automatically.
 
@@ -23,6 +25,17 @@ particularly regarding the base.
 height.
 4. Integrate this heuristic into the primary application to provide a default value for base height, reducing user
 input requirements.
+
+To exclude the base, we needed a heuristic to identify where the figurine ends and the base begins. Our analysis of
+real-world STL models revealed that the base height is consistently around 19% of the total figure height.
+
+The constant is defined as:
+
+```python
+BASE_HEIGHT_PERCENTAGE = 0.19
+```
+
+It is stored in the use case layer in a `constants.py` module for reuse across the transformation logic.
 
 ## Utility Description
 
@@ -55,11 +68,16 @@ heuristic.
 - Simplifies the user interface by automating base height estimation.
 - Improves accuracy in transformations by excluding the base from calculations.
 - Encourages data-driven decision-making in the application design.
+-This heuristic simplifies the user experience by automatically excluding the base without requiring user input.
+It aligns our transformation logic more closely with the geometry of humanoid figurines, improving accuracy.
 
 ### Negative
 
 - The heuristic may not be accurate for unusual or atypical figurine models.
 - Requires maintenance of the utility for further refinement of the heuristic.
+- The heuristic might not be perfect for all models. Some figurines could have non-standard bases that are taller or
+shorter than the assumed 19%.
+- Future adjustments may be necessary as more data becomes available.
 
 ## Alternatives Considered
 

--- a/tests/use_cases/test_mesh_dimensions.py
+++ b/tests/use_cases/test_mesh_dimensions.py
@@ -32,12 +32,12 @@ def test_calculate_radius():
     """
     # Create a simple cylindrical mesh with vertices representing a unit cylinder
     vertices = [
-        (1, 0, 0),  # Vertex at radius 1 along x-axis
-        (0, 1, 0),  # Vertex at radius 1 along y-axis
-        (-1, 0, 0),  # Vertex at radius 1 along -x-axis
-        (0, -1, 0),  # Vertex at radius 1 along -y-axis
-        (0.707, 0.707, 0),  # Vertex at radius ~1 along diagonal
-        (-0.707, -0.707, 0),  # Vertex at radius ~1 along opposite diagonal
+        (1, 0, 1),  # Vertex at radius 1 along x-axis
+        (0, 1, 1),  # Vertex at radius 1 along y-axis
+        (-1, 0, 1),  # Vertex at radius 1 along -x-axis
+        (0, -1, 1),  # Vertex at radius 1 along -y-axis
+        (0.707, 0.707, 1),  # Vertex at radius ~1 along diagonal
+        (-0.707, -0.707, 1),  # Vertex at radius ~1 along opposite diagonal
     ]
 
     faces = []  # Faces are irrelevant for radius calculation
@@ -68,8 +68,8 @@ def test_calculate_height_empty_mesh():
 
 
 def test_calculate_radius_origin_mesh():
-    """Test radius calculation with all vertices at origin."""
-    origin_mesh = Mesh(vertices=[(0, 0, 0), (0, 0, 0), (0, 0, 0)], faces=[(0, 1, 2)])
+    """Test radius calculation with x,y vertices at origin."""
+    origin_mesh = Mesh(vertices=[(0, 0, 1), (0, 0, 1), (0, 0, 1)], faces=[(0, 1, 2)])
     radius = calculate_mesh_radius(origin_mesh)
     assert radius == 0, "Expected radius of origin-only mesh to be 0"
 

--- a/tests/use_cases/test_process_thickening.py
+++ b/tests/use_cases/test_process_thickening.py
@@ -2,7 +2,14 @@
 
 from unittest.mock import Mock
 
-from thicker.use_cases.thicken_mesh import process_thickening, process_thickening_ori
+import pytest
+
+from thicker.domain.mesh import Mesh
+from thicker.use_cases.thicken_mesh import (
+    calculate_mesh_radius,
+    process_thickening,
+    process_thickening_ori,
+)
 
 
 def test_process_thickening_ori():
@@ -43,3 +50,84 @@ def test_process_thickening():
     # Assertions
     mock_reader.read.assert_called_once()
     mock_writer.write.assert_called_once()
+
+
+def test_calculate_mesh_radius_excludes_base():
+    """
+    Test that the mesh radius calculation ignores vertices in the bottom
+    19% of the figure's height.
+    """
+
+    # Create a simple mesh with a base and figure
+    vertices = [
+        # Base vertices
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (-1.0, 0.0, 0.0),
+        (0.0, -1.0, 0.0),
+        # Figure vertices (above base)
+        (0.5, 0.0, 1.0),
+        (0.0, 0.5, 1.0),
+        (-0.5, 0.0, 1.0),
+        (0.0, -0.5, 1.0),
+    ]
+    faces = []  # Faces are irrelevant for this test
+    mesh = Mesh(vertices=vertices, faces=faces)
+
+    # Calculate radius
+    radius = calculate_mesh_radius(mesh)
+
+    # The radius should be calculated from vertices above 0.38 (19% of 2.0)
+    # Expected max radius should be 0.5 (ignoring the lower vertices)
+    expected_radius = 0.5
+    assert pytest.approx(radius, rel=1e-2) == expected_radius, \
+        f"Expected radius {expected_radius}, got {radius}"
+
+
+def test_calculate_radius_no_vertices_above_base():
+    """
+    Test that calculate_mesh_radius raises a ValueError if no vertices are found
+    above the base height.
+    """
+    # Create a mesh where all vertices are at or below the base height
+    vertices = [
+        (1, 0, 0),  # All vertices at z = 0
+        (0, 1, 0),
+        (-1, 0, 0),
+        (0, -1, 0),
+    ]
+    faces = []  # Faces are irrelevant for this test
+    mesh = Mesh(vertices=vertices, faces=faces)
+
+    # Expect a ValueError to be raised
+    with pytest.raises(ValueError, match="No vertices found above the base height."):
+        calculate_mesh_radius(mesh)
+
+
+def test_calculate_radius_one_vertex_above_base():
+    """
+    Test that the function calculates the radius correctly for a mesh with only
+    one vertex above the base height.
+    """
+    vertices = [
+        (1, 0, 0),  # Base vertex (ignored)
+        (0, 1, 0),  # Base vertex (ignored)
+        (0, 0, 5),  # One vertex above base height
+    ]
+    mesh = Mesh(vertices=vertices, faces=[])
+
+    # Expected radius is the distance from the z-axis to (0, 0, 5)
+    expected_radius = 0.0
+
+    radius = calculate_mesh_radius(mesh)
+    assert pytest.approx(radius, rel=1e-3) == expected_radius
+
+
+def test_calculate_radius_empty_mesh():
+    """
+    Test that an empty mesh raises a ValueError.
+    """
+    mesh = Mesh(vertices=[], faces=[])
+
+    with pytest.raises(ValueError, match="Mesh contains no vertices."):
+        calculate_mesh_radius(mesh)

--- a/thicker/use_cases/constants.py
+++ b/thicker/use_cases/constants.py
@@ -1,0 +1,4 @@
+""" Constants for use cases. """
+
+# Heuristic value for base height as a fraction of mesh height
+BASE_HEIGHT_PERCENTAGE = 0.19


### PR DESCRIPTION
Visually inspected results OK.

![image](https://github.com/user-attachments/assets/cf7c35aa-9155-47d2-8645-36209c213d86)

## Summary by Sourcery

Tests:
- Added tests for `calculate_mesh_radius` to verify the base exclusion logic.