### PR TITLE
Basic cross-section detection and thickening for cylindrical shapes aligned to the z-axis 

### DIFF
--- a/tests/domain/test_cross_section_analysis.py
+++ b/tests/domain/test_cross_section_analysis.py
@@ -1,0 +1,85 @@
+""" Test cross-section analysis domain code."""
+
+from thicker.domain.cross_section_analysis import detect_narrow_cross_sections
+from thicker.domain.mesh import Mesh
+
+
+def test_no_narrow_cross_sections_in_uniform_cylinder():
+    """
+    Test that no narrow cross-sections are detected in a simple uniform cylinder.
+    """
+    # Hardcoded vertex and face data for a simple unit cylinder
+    vertices = [
+        (1, 0, 0),  # Point on circumference, bottom
+        (0, 1, 0),  # Point on circumference, bottom
+        (-1, 0, 0),  # Point on circumference, bottom
+        (0, -1, 0),  # Point on circumference, bottom
+        (1, 0, 1),  # Point on circumference, top
+        (0, 1, 1),  # Point on circumference, top
+        (-1, 0, 1),  # Point on circumference, top
+        (0, -1, 1),  # Point on circumference, top
+    ]
+
+    faces = [
+        (0, 1, 4),
+        (1, 5, 4),  # Side faces
+        (1, 2, 5),
+        (2, 6, 5),  # Side faces
+        (2, 3, 6),
+        (3, 7, 6),  # Side faces
+        (3, 0, 7),
+        (0, 4, 7),  # Side faces
+        (0, 1, 2, 3),  # Bottom cap
+        (4, 5, 6, 7),  # Top cap
+    ]
+
+    # Create the mesh
+    mesh = Mesh(vertices=vertices, faces=faces)
+
+    # Run the narrow cross-section detection
+    narrow_sections = detect_narrow_cross_sections(mesh, threshold=0.5)
+
+    # Assert that no narrow cross-sections were found
+    assert (
+        narrow_sections == []
+    ), f"Expected no narrow cross-sections, but found {narrow_sections}"
+
+
+def test_detect_narrow_waist():
+    """
+    Test to detect a narrow waist feature in a cylindrical mesh.
+    The mesh has a wide base, a narrow middle section (waist),
+    and a wide top.
+    """
+    # Create vertices for a mesh with a narrow waist
+    vertices = [
+        # Base section (radius 1.0)
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (-1.0, 0.0, 0.0),
+        (0.0, -1.0, 0.0),
+        # Narrow waist (radius 0.4)
+        (0.4, 0.0, 0.5),
+        (0.0, 0.4, 0.5),
+        (-0.4, 0.0, 0.5),
+        (0.0, -0.4, 0.5),
+        # Top section (radius 1.0)
+        (1.0, 0.0, 1.0),
+        (0.0, 1.0, 1.0),
+        (-1.0, 0.0, 1.0),
+        (0.0, -1.0, 1.0),
+    ]
+
+    # Faces are not relevant for cross-section detection
+    faces = []
+
+    # Create the Mesh object
+    mesh = Mesh(vertices=vertices, faces=faces)
+
+    # Call the function with a threshold of 0.5
+    narrow_sections = detect_narrow_cross_sections(mesh, threshold=0.5)
+
+    # Validate that the narrow section is detected at the expected height
+    assert narrow_sections == [
+        0.5
+    ], f"Expected narrow section at z=0.5, got {narrow_sections}"

--- a/tests/domain/test_cross_section_thickening.py
+++ b/tests/domain/test_cross_section_thickening.py
@@ -1,0 +1,48 @@
+""" Test cross-section thickening. """
+
+import math
+
+from thicker.domain.cross_section_thickening import thicken_cross_section
+from thicker.domain.mesh import Mesh
+
+
+def test_thicken_cross_section():
+    """
+    Test that a narrow cross-section is correctly thickened.
+    """
+    # Vertices for a cylinder with a narrow waist at z=0.5
+    vertices = [
+        (1.0, 0.0, 0.0),  # Base
+        (0.5, 0.0, 0.5),  # Narrow section
+        (1.0, 0.0, 1.0),  # Top
+    ]
+    faces = []  # Faces are not relevant for this test
+
+    mesh = Mesh(vertices=vertices, faces=faces)
+
+    # Define the narrow section and the offset
+    narrow_sections = [0.5]
+    offset = 0.2
+
+    # Apply the thickening transformation
+    thickened_mesh = thicken_cross_section(mesh, narrow_sections, offset)
+
+    # Assert that the narrow section was thickened
+    assert math.isclose(
+        thickened_mesh.vertices[1][0], (0.7, 0.0, 0.5)[0], rel_tol=1e-5
+    ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+    assert math.isclose(
+        thickened_mesh.vertices[1][1], (0.7, 0.0, 0.5)[1], rel_tol=1e-5
+    ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+    assert math.isclose(
+        thickened_mesh.vertices[1][2], (0.7, 0.0, 0.5)[2], rel_tol=1e-5
+    ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+
+    # Assert that other sections remain unchanged
+    assert math.isclose(thickened_mesh.vertices[0][0], (1.0, 0.0, 0.0)[0], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[0][1], (1.0, 0.0, 0.0)[1], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[0][2], (1.0, 0.0, 0.0)[2], rel_tol=1e-5)
+
+    assert math.isclose(thickened_mesh.vertices[2][0], (1.0, 0.0, 1.0)[0], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[2][1], (1.0, 0.0, 1.0)[1], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[2][2], (1.0, 0.0, 1.0)[2], rel_tol=1e-5)

--- a/tests/use_cases/test_mesh_dimensions.py
+++ b/tests/use_cases/test_mesh_dimensions.py
@@ -50,8 +50,8 @@ def test_calculate_radius():
 
     # Assert that the calculated radius matches the expected value
     expected_radius = 1.0
-    assert (
-        math.isclose(radius, expected_radius, rel_tol=1e-09, abs_tol=1e-09)
+    assert math.isclose(
+        radius, expected_radius, rel_tol=1e-09, abs_tol=1e-09
     ), f"Expected radius {expected_radius}, got {radius}"
 
 

--- a/tests/use_cases/test_process_thickening.py
+++ b/tests/use_cases/test_process_thickening.py
@@ -81,8 +81,9 @@ def test_calculate_mesh_radius_excludes_base():
     # The radius should be calculated from vertices above 0.38 (19% of 2.0)
     # Expected max radius should be 0.5 (ignoring the lower vertices)
     expected_radius = 0.5
-    assert (math.isclose(radius, expected_radius, rel_tol=1e-09, abs_tol=1e-09)), \
-        f"Expected radius {expected_radius}, got {radius}"
+    assert math.isclose(
+        radius, expected_radius, rel_tol=1e-09, abs_tol=1e-09
+    ), f"Expected radius {expected_radius}, got {radius}"
 
 
 def test_calculate_radius_no_vertices_above_base():
@@ -121,8 +122,9 @@ def test_calculate_radius_one_vertex_above_base():
     expected_radius = 0.0
 
     radius = calculate_mesh_radius(mesh)
-    assert (math.isclose(radius, expected_radius, rel_tol=1e-09, abs_tol=1e-09)), \
-        f"Expected radius {expected_radius}, got {radius}"
+    assert math.isclose(
+        radius, expected_radius, rel_tol=1e-09, abs_tol=1e-09
+    ), f"Expected radius {expected_radius}, got {radius}"
 
 
 def test_calculate_radius_empty_mesh():

--- a/thicker/domain/cross_section_analysis.py
+++ b/thicker/domain/cross_section_analysis.py
@@ -1,0 +1,46 @@
+""" Cross-section analysis of meshes. """
+
+from thicker.domain.mesh import Mesh
+
+
+def detect_narrow_cross_sections(mesh: Mesh, threshold: float = 0.5) -> list[float]:
+    """
+    Detect narrow cross-sections in a given mesh.
+
+    Args:
+        mesh: The Mesh object containing vertices and faces.
+        threshold: The minimum allowable radius for a cross-section.
+
+    Returns:
+        A list of z-heights where the cross-section radius is below the threshold.
+    """
+    narrow_sections = []
+    z_values = [z for _, _, z in mesh.vertices]
+
+    # Determine the height range of the mesh
+    min_z = min(z_values)
+    max_z = max(z_values)
+    num_slices = 100  # Number of horizontal slices to analyze
+
+    slice_height = (max_z - min_z) / num_slices
+
+    for i in range(num_slices):
+        slice_z_min = min_z + i * slice_height
+        slice_z_max = slice_z_min + slice_height
+
+        # Get vertices in this slice
+        slice_vertices = [
+            (x, y) for x, y, z in mesh.vertices if slice_z_min <= z < slice_z_max
+        ]
+
+        if not slice_vertices:
+            continue  # Skip empty slices
+
+        # Calculate the max distance from the z-axis
+        max_radius = max((x ** 2 + y ** 2) ** 0.5 for x, y in slice_vertices)
+
+        # Check if the radius is below the threshold
+        if max_radius < threshold:
+            narrow_sections.append(slice_z_min)
+
+    return narrow_sections

--- a/thicker/domain/cross_section_thickening.py
+++ b/thicker/domain/cross_section_thickening.py
@@ -1,0 +1,45 @@
+""" Thicken narrow cross-sections. """
+
+import math
+
+from thicker.domain.mesh import Mesh
+
+
+def thicken_cross_section(mesh: Mesh, narrow_sections, offset: float) -> Mesh:
+    threshold = 1.0
+    thickener = CrossSectionThickener(threshold, offset)
+    thickened_mesh = thickener.thicken(mesh, narrow_sections)
+    assert isinstance(thickened_mesh, Mesh), "Argument of wrong type!"
+    return thickened_mesh
+
+
+class CrossSectionThickener:
+    def __init__(self, threshold: float, offset: float):
+        self.threshold = threshold
+        self.offset = offset
+
+    def thicken(self, mesh: Mesh, narrow_sections: list[float]) -> Mesh:
+        """
+        Thicken the narrow cross sections of the mesh.
+
+        Args:
+            mesh: The original mesh to be thickened.
+            narrow_sections: A list of z-heights where narrow cross sections
+                were detected.
+
+        Returns:
+            A new Mesh object with thickened cross sections.
+        """
+        new_vertices = []
+        for x, y, z in mesh.vertices:
+            # Adjust vertices at detected narrow sections
+            if any(math.isclose(z, height, abs_tol=0.01) for height in narrow_sections):
+                distance = (x ** 2 + y ** 2) ** 0.5
+                factor = (distance + self.offset) / distance
+                new_x = x * factor
+                new_y = y * factor
+                new_vertices.append((new_x, new_y, z))
+            else:
+                new_vertices.append((x, y, z))
+
+        return Mesh(vertices=new_vertices, faces=mesh.faces)

--- a/thicker/use_cases/constants.py
+++ b/thicker/use_cases/constants.py
@@ -1,4 +1,4 @@
-""" Constants for use cases. """
+"""Constants for use cases."""
 
 # Heuristic value for base height as a fraction of mesh height
 BASE_HEIGHT_PERCENTAGE = 0.19

--- a/thicker/use_cases/thicken_mesh.py
+++ b/thicker/use_cases/thicken_mesh.py
@@ -91,9 +91,7 @@ def calculate_mesh_radius(mesh: Mesh) -> float:
     base_height = BASE_HEIGHT_PERCENTAGE * calculate_mesh_height(mesh)
 
     # Filter vertices above the base height
-    vertices_above_base = [
-        (x, y) for x, y, z in mesh.vertices if z > base_height
-    ]
+    vertices_above_base = [(x, y) for x, y, z in mesh.vertices if z > base_height]
 
     if not vertices_above_base:
         raise ValueError("No vertices found above the base height.")


### PR DESCRIPTION
🔬 Approach to Thickening Thin Cross Sections
1️⃣ Step 1: Identify Thin Cross Sections and Their Vertices
Once we've detected a thin cross section at a particular z-height, the next task is to determine which vertices belong to that cross section. These vertices need to be adjusted to increase their distance from the z-axis.

2️⃣ Step 2: Apply a Targeted Thickening Transformation
For each detected thin cross section, apply a transformation to:

Move vertices outward from the z-axis by a specified offset.
Ensure the thickening is proportional to the thin section's original radius, so we don’t over-thicken narrow areas.
🔧 Transformation Formula (for Cross Section)
For each vertex 

$(x,y,z)$ in a thin cross section:

$𝑟_{new} = 𝑟_{current} + offset$

Where:

$𝑟_{current} = \sqrt(𝑥^2 + y^2)$   (current distance from the z-axis)

$𝑟_{new}$  is the new radius after thickening.

offset is the amount to thicken the cross section.

## Summary by Sourcery

Implement cross-section thickening for cylindrical meshes. Detect narrow cross-sections based on a threshold and thicken them by a specified offset.

New Features:
- Detect narrow cross-sections in cylindrical meshes aligned to the z-axis.
- Thicken narrow cross-sections of cylindrical meshes.

Tests:
- Add tests for cross-section analysis and thickening.