### PR TITLE
Add offset cylinder test

### DIFF
--- a/docs/adrs/014-cross-section-centroid-thickening.md
+++ b/docs/adrs/014-cross-section-centroid-thickening.md
@@ -1,0 +1,60 @@
+# Centroid-Based Thickening for Vertical Slices**
+
+## Status
+
+Accepted
+
+## Date
+
+January 5, 2025
+
+## Context
+
+The existing cylindrical thickening transformation improves the robustness of 3D printed models by thickening narrow
+vertical sections based on their distance from the z-axis. However, this approach is limited to models where narrow
+features (such as limbs) are approximately aligned with the z-axis. It also fails to account for offset features, such
+as arms or legs that are not centered on the z-axis.
+
+In practice, many figurines have limbs or other features that are offset from the central vertical axis of the model.
+For example, arms outstretched to the sides or legs positioned away from the center will not be properly thickened if
+the transformation assumes the z-axis is the center of the cross-section. To improve thickening accuracy, we need to
+shift from z-axis-based thickening to **centroid-based thickening** of detected narrow cross-sections.
+
+## Decision
+
+We will implement **centroid-based thickening** for vertical slices:
+
+- Each detected **narrow cross-section** will be treated as a slice of vertices.
+- The **centroid** of each slice will be calculated to determine the "local axis" for thickening.
+- The thickening transformation will apply an offset normal to the centroid, ensuring that the cross-section is
+- thickened **around its own axis** rather than the global z-axis.
+
+In cases where a vertex coincides with the centroid (resulting in a zero difference), no thickening will be
+applied along that axis to avoid division by zero errors.
+
+## Consequences
+
+✅ **Benefits:**
+
+- More accurate thickening for offset features like arms, legs, and hands.
+- The transformation adapts to the unique geometry of each narrow cross-section, ensuring uniform thickening.
+- Lays the foundation for handling non-vertical limbs in future work.
+
+⚠️ **Trade-offs:**
+
+- **Increased computational complexity:** Calculating centroids and applying localized transformations requires
+- more processing than a simple cylindrical thickening.
+- **Additional handling for edge cases:** Division by zero and edge cases where vertices align with centroids require
+- careful handling.
+
+## Alternatives Considered
+
+1. **Continue with z-axis-based thickening:**
+   Rejected, as it cannot accurately thicken offset or angled features.
+
+2. **Use bounding boxes or spheres to detect narrow features:**
+   Rejected due to lack of precision compared to centroid-based thickening.
+
+## Decision Makers
+
+Tom Willis

--- a/tests/domain/test_cross_section_analysis.py
+++ b/tests/domain/test_cross_section_analysis.py
@@ -1,7 +1,8 @@
-""" Test cross-section analysis domain code."""
+"""Test cross-section analysis domain code."""
 
 from thicker.domain.cross_section_analysis import detect_narrow_cross_sections
 from thicker.domain.mesh import Mesh
+from thicker.domain.slice import Slice
 
 
 def test_no_narrow_cross_sections_in_uniform_cylinder():
@@ -37,12 +38,12 @@ def test_no_narrow_cross_sections_in_uniform_cylinder():
     mesh = Mesh(vertices=vertices, faces=faces)
 
     # Run the narrow cross-section detection
-    narrow_sections = detect_narrow_cross_sections(mesh, threshold=0.5)
+    narrow_slices: list[Slice] = detect_narrow_cross_sections(mesh, threshold=0.5)
 
     # Assert that no narrow cross-sections were found
     assert (
-        narrow_sections == []
-    ), f"Expected no narrow cross-sections, but found {narrow_sections}"
+        narrow_slices == []
+    ), f"Expected no narrow cross-sections, but found {narrow_slices}"
 
 
 def test_detect_narrow_waist():
@@ -77,9 +78,19 @@ def test_detect_narrow_waist():
     mesh = Mesh(vertices=vertices, faces=faces)
 
     # Call the function with a threshold of 0.5
-    narrow_sections = detect_narrow_cross_sections(mesh, threshold=0.5)
-
-    # Validate that the narrow section is detected at the expected height
-    assert narrow_sections == [
-        0.5
-    ], f"Expected narrow section at z=0.5, got {narrow_sections}"
+    narrow_sections: list[Slice] = detect_narrow_cross_sections(mesh, threshold=0.5)
+    expected_slices = [
+        Slice(
+            vertices=[
+                (0.4, 0.0, 0.5),
+                (0.0, 0.4, 0.5),
+                (-0.4, 0.0, 0.5),
+                (0.0, -0.4, 0.5),
+            ],
+            z_height=0.5,
+        ),
+    ]
+    # Validate that the one narrow section is detected at the expected height
+    assert (
+        narrow_sections[0] == expected_slices[0]
+    ), f"Expected narrow section at z=0.5, got {narrow_sections[0]}"

--- a/tests/domain/test_cross_section_thickening.py
+++ b/tests/domain/test_cross_section_thickening.py
@@ -1,9 +1,10 @@
-""" Test cross-section thickening. """
+"""Test cross-section thickening."""
 
 import math
 
 from thicker.domain.cross_section_thickening import thicken_cross_section
 from thicker.domain.mesh import Mesh
+from thicker.domain.slice import Slice
 
 
 def test_thicken_cross_section():
@@ -13,7 +14,11 @@ def test_thicken_cross_section():
     # Vertices for a cylinder with a narrow waist at z=0.5
     vertices = [
         (1.0, 0.0, 0.0),  # Base
-        (0.5, 0.0, 0.5),  # Narrow section
+        # Narrow section
+        (0.5, 0.0, 0.5),
+        (0.0, 0.5, 0.5),
+        (-0.5, 0.0, 0.5),
+        (0.0, -0.5, 0.5),
         (1.0, 0.0, 1.0),  # Top
     ]
     faces = []  # Faces are not relevant for this test
@@ -21,11 +26,17 @@ def test_thicken_cross_section():
     mesh = Mesh(vertices=vertices, faces=faces)
 
     # Define the narrow section and the offset
-    narrow_sections = [0.5]
+    # narrow_sections = [0.5]
     offset = 0.2
+    narrow_slice = Slice(
+        vertices=[vertices[1], vertices[2], vertices[3], vertices[4]], z_height=0.5
+    )
+    narrow_slices = [
+        narrow_slice,
+    ]
 
     # Apply the thickening transformation
-    thickened_mesh = thicken_cross_section(mesh, narrow_sections, offset)
+    thickened_mesh = thicken_cross_section(mesh, narrow_slices, offset)
 
     # Assert that the narrow section was thickened
     assert math.isclose(
@@ -43,6 +54,49 @@ def test_thicken_cross_section():
     assert math.isclose(thickened_mesh.vertices[0][1], (1.0, 0.0, 0.0)[1], rel_tol=1e-5)
     assert math.isclose(thickened_mesh.vertices[0][2], (1.0, 0.0, 0.0)[2], rel_tol=1e-5)
 
-    assert math.isclose(thickened_mesh.vertices[2][0], (1.0, 0.0, 1.0)[0], rel_tol=1e-5)
-    assert math.isclose(thickened_mesh.vertices[2][1], (1.0, 0.0, 1.0)[1], rel_tol=1e-5)
-    assert math.isclose(thickened_mesh.vertices[2][2], (1.0, 0.0, 1.0)[2], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[5][0], (1.0, 0.0, 1.0)[0], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[5][1], (1.0, 0.0, 1.0)[1], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[5][2], (1.0, 0.0, 1.0)[2], rel_tol=1e-5)
+
+
+# def test_thicken_offset_cross_section():
+#     """
+#     Test that a narrow cross-section is correctly thickened.
+#     """
+#     # Vertices for a cylinder with a narrow waist at z=0.5
+#     # that is offset in y from the z-axis
+#     vertices = [
+#         (1.0, 2.0, 0.0),  # Base
+#         (0.5, 2.0, 0.5),  # Narrow section
+#         (1.0, 2.0, 1.0),  # Top
+#     ]
+#     faces = []  # Faces are not relevant for this test
+#
+#     mesh = Mesh(vertices=vertices, faces=faces)
+#
+#     # Define the narrow section and the offset
+#     narrow_sections = [0.5]
+#     offset = 0.2
+#
+#     # Apply the thickening transformation
+#     thickened_mesh = thicken_cross_section(mesh, narrow_sections, offset)
+#
+#     # Assert that the narrow section was thickened
+#     assert math.isclose(
+#         thickened_mesh.vertices[1][0], vertices[1][0], rel_tol=1e-5
+#     ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+#     assert math.isclose(
+#         thickened_mesh.vertices[1][1], vertices[1][1], rel_tol=1e-5
+#     ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+#     assert math.isclose(
+#         thickened_mesh.vertices[1][2], vertices[1][2], rel_tol=1e-5
+#     ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+#
+#     # Assert that other sections remain unchanged
+#     assert math.isclose(thickened_mesh.vertices[0][0], vertices[0][0], rel_tol=1e-5)
+#     assert math.isclose(thickened_mesh.vertices[0][1], vertices[0][1], rel_tol=1e-5)
+#     assert math.isclose(thickened_mesh.vertices[0][2], vertices[0][2], rel_tol=1e-5)
+#
+#     assert math.isclose(thickened_mesh.vertices[2][0], vertices[2][0], rel_tol=1e-5)
+#     assert math.isclose(thickened_mesh.vertices[2][1], vertices[2][1], rel_tol=1e-5)
+#     assert math.isclose(thickened_mesh.vertices[2][2], vertices[2][2], rel_tol=1e-5)

--- a/tests/domain/test_cross_section_thickening.py
+++ b/tests/domain/test_cross_section_thickening.py
@@ -26,14 +26,11 @@ def test_thicken_cross_section():
     mesh = Mesh(vertices=vertices, faces=faces)
 
     # Define the narrow section and the offset
-    # narrow_sections = [0.5]
     offset = 0.2
     narrow_slice = Slice(
         vertices=[vertices[1], vertices[2], vertices[3], vertices[4]], z_height=0.5
     )
-    narrow_slices = [
-        narrow_slice,
-    ]
+    narrow_slices = [ narrow_slice, ]
 
     # Apply the thickening transformation
     thickened_mesh = thicken_cross_section(mesh, narrow_slices, offset)
@@ -59,44 +56,52 @@ def test_thicken_cross_section():
     assert math.isclose(thickened_mesh.vertices[5][2], (1.0, 0.0, 1.0)[2], rel_tol=1e-5)
 
 
-# def test_thicken_offset_cross_section():
-#     """
-#     Test that a narrow cross-section is correctly thickened.
-#     """
-#     # Vertices for a cylinder with a narrow waist at z=0.5
-#     # that is offset in y from the z-axis
-#     vertices = [
-#         (1.0, 2.0, 0.0),  # Base
-#         (0.5, 2.0, 0.5),  # Narrow section
-#         (1.0, 2.0, 1.0),  # Top
-#     ]
-#     faces = []  # Faces are not relevant for this test
-#
-#     mesh = Mesh(vertices=vertices, faces=faces)
-#
-#     # Define the narrow section and the offset
-#     narrow_sections = [0.5]
-#     offset = 0.2
-#
-#     # Apply the thickening transformation
-#     thickened_mesh = thicken_cross_section(mesh, narrow_sections, offset)
-#
-#     # Assert that the narrow section was thickened
-#     assert math.isclose(
-#         thickened_mesh.vertices[1][0], vertices[1][0], rel_tol=1e-5
-#     ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
-#     assert math.isclose(
-#         thickened_mesh.vertices[1][1], vertices[1][1], rel_tol=1e-5
-#     ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
-#     assert math.isclose(
-#         thickened_mesh.vertices[1][2], vertices[1][2], rel_tol=1e-5
-#     ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
-#
-#     # Assert that other sections remain unchanged
-#     assert math.isclose(thickened_mesh.vertices[0][0], vertices[0][0], rel_tol=1e-5)
-#     assert math.isclose(thickened_mesh.vertices[0][1], vertices[0][1], rel_tol=1e-5)
-#     assert math.isclose(thickened_mesh.vertices[0][2], vertices[0][2], rel_tol=1e-5)
-#
-#     assert math.isclose(thickened_mesh.vertices[2][0], vertices[2][0], rel_tol=1e-5)
-#     assert math.isclose(thickened_mesh.vertices[2][1], vertices[2][1], rel_tol=1e-5)
-#     assert math.isclose(thickened_mesh.vertices[2][2], vertices[2][2], rel_tol=1e-5)
+def test_thicken_offset_cross_section():
+    """
+    Test that a narrow cross-section is correctly thickened.
+    """
+    # Vertices for a cylinder with a narrow waist at z=0.5
+    # that is offset in y from the z-axis
+    vertices = [
+        (1.0, 2.0, 0.0),  # Base
+        # Narrow section
+        (0.5, 2.0, 0.5),
+        (0.0, 2.5, 0.5),
+        (-0.5, 2.0, 0.5),
+        (0.0, -2.5, 0.5),
+        (1.0, 2.0, 1.0),  # Top
+    ]
+    faces = []  # Faces are not relevant for this test
+
+    mesh = Mesh(vertices=vertices, faces=faces)
+
+    # Define the narrow section and the offset
+    offset = 0.2
+    narrow_slice = Slice(
+        vertices=[vertices[1], vertices[2], vertices[3], vertices[4]], z_height=0.5
+    )
+    narrow_slices = [ narrow_slice, ]
+
+    # Apply the thickening transformation
+    thickened_mesh = thicken_cross_section(mesh, narrow_slices, offset)
+
+    # Assert that the narrow section was thickened
+    assert math.isclose(
+        thickened_mesh.vertices[1][0], (0.7, 2.2, 0.5)[0], rel_tol=1e-5
+    ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+    assert math.isclose(
+        thickened_mesh.vertices[1][1], (0.7, 2.2, 0.5)[1], rel_tol=1e-5
+    ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+    assert math.isclose(
+        thickened_mesh.vertices[1][2], (0.7, 2.2, 0.5)[2], rel_tol=1e-5
+    ), f"Expected vertex to be thickened, got {thickened_mesh.vertices[1]}"
+
+
+    # Assert that other sections remain unchanged
+    assert math.isclose(thickened_mesh.vertices[0][0], vertices[0][0], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[0][1], vertices[0][1], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[0][2], vertices[0][2], rel_tol=1e-5)
+
+    assert math.isclose(thickened_mesh.vertices[5][0], vertices[5][0], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[5][1], vertices[5][1], rel_tol=1e-5)
+    assert math.isclose(thickened_mesh.vertices[5][2], vertices[5][2], rel_tol=1e-5)

--- a/tests/domain/test_mesh.py
+++ b/tests/domain/test_mesh.py
@@ -40,8 +40,8 @@ def test_inequality():
     assert mesh2 != mesh3
 
 
-def test_bad_class():
-    """Test meshes are equal to strings."""
+def test_bad_class_eq():
+    """Test if Meshes are equal to strings."""
     vertices = [(0, 0, 0), (1, 0, 0), (0, 1, 0)]
     faces = [(0, 1, 2)]
 

--- a/tests/domain/test_slice.py
+++ b/tests/domain/test_slice.py
@@ -14,3 +14,73 @@ def test_slice_initialization():
 
     assert slice_obj.vertices == vertices
     assert slice_obj.z_height == z_height
+
+
+def test_slice_centroid():
+    """
+    Test that the centroid of a Slice is calculated correctly.
+    """
+    vertices = [(0.0, 0.0, 0.5), (1.0, 0.0, 0.5), (0.0, 1.0, 0.5), (1.0, 1.0, 0.5)]
+    z_height = 0.5
+    slice_obj = Slice(vertices=vertices, z_height=z_height)
+
+    expected_centroid = (0.5, 0.5)
+    assert (
+        slice_obj.centroid() == expected_centroid
+    ), f"Expected centroid {expected_centroid}, got {slice_obj.centroid()}"
+
+
+def test_slice_centroid_irregular():
+    """
+    Test that the centroid of a Slice is correctly calculated for irregular vertices.
+    """
+    vertices = [(2.0, 3.0, 0.5), (3.0, 4.0, 0.5), (4.0, 3.0, 0.5)]
+    z_height = 0.5
+    slice_obj = Slice(vertices=vertices, z_height=z_height)
+
+    expected_centroid = (3.0, 3.3333333333333335)  # (sum of x) / 3, (sum of y) / 3
+    assert (
+        slice_obj.centroid() == expected_centroid
+    ), f"Expected centroid {expected_centroid}, got {slice_obj.centroid()}"
+
+
+def test_slice_empty_vertices():
+    """
+    Test that a Slice with no vertices returns a (0.0, 0.0) centroid.
+    """
+    vertices = []
+    z_height = 0.5
+    slice_obj = Slice(vertices=vertices, z_height=z_height)
+
+    expected_centroid = (0.0, 0.0)
+    assert (
+        slice_obj.centroid() == expected_centroid
+    ), f"Expected centroid {expected_centroid}, got {slice_obj.centroid()}"
+
+
+def test_slice_single_vertex():
+    """
+    Test that the centroid is the single vertex itself when there is only one vertex.
+    """
+    vertices = [(1.0, 2.0, 0.5)]
+    z_height = 0.5
+    slice_obj = Slice(vertices=vertices, z_height=z_height)
+
+    expected_centroid = (1.0, 2.0)
+    assert (
+        slice_obj.centroid() == expected_centroid
+    ), f"Expected centroid {expected_centroid}, got {slice_obj.centroid()}"
+
+
+def test_slice_collinear_vertices():
+    """
+    Test that the centroid is correctly calculated for collinear vertices.
+    """
+    vertices = [(1.0, 2.0, 0.5), (2.0, 4.0, 0.5), (3.0, 6.0, 0.5)]
+    z_height = 0.5
+    slice_obj = Slice(vertices=vertices, z_height=z_height)
+
+    expected_centroid = (2.0, 4.0)  # The average of x and y coordinates
+    assert (
+        slice_obj.centroid() == expected_centroid
+    ), f"Expected centroid {expected_centroid}, got {slice_obj.centroid()}"

--- a/tests/domain/test_slice.py
+++ b/tests/domain/test_slice.py
@@ -211,3 +211,16 @@ def test_slice_vertices_equality():
         z_height=0.5,
     )
     assert slice_left == slice_right, f"Expect {slice_left} == {slice_right}"
+
+def test_bad_class_eq():
+    """Test if Slices are equal to strings."""
+    a_slice = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+        ],
+        z_height=0.5,
+    )
+
+    a_string = "moof"
+
+    assert a_slice != a_string

--- a/tests/domain/test_slice.py
+++ b/tests/domain/test_slice.py
@@ -1,5 +1,6 @@
-""" test the Slice class. """
+"""test the Slice class."""
 
+import math
 
 from thicker.domain.slice import Slice
 
@@ -14,7 +15,7 @@ def test_slice_initialization():
     slice_obj = Slice(vertices=vertices, z_height=z_height)
 
     assert slice_obj.vertices == vertices
-    assert slice_obj.z_height == z_height
+    assert math.isclose(slice_obj.z_height, z_height)
 
 
 def test_slice_centroid():
@@ -143,3 +144,70 @@ def test_slice_repr_more_than_three_vertices():
         "vertices=[(1.0, 2.0, 0.0), (0.5, 1.5, 0.5), (0.7, 1.8, 1.0)], ...)"
     )
     assert repr(slice_obj) == expected, f"Unexpected repr: {repr(slice_obj)}"
+
+
+def test_slice_vertices_inequality():
+    """Test slice inequality in vertices."""
+    slice_left = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+            (0.0, 0.4, 0.5),
+            (-0.4, 0.0, 0.5),
+            (0.0, -0.4, 0.5),
+        ],
+        z_height=0.5,
+    )
+    slice_right = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+            (0.0, 0.4, 0.5),
+        ],
+        z_height=0.5,
+    )
+    assert slice_left != slice_right, f"Expect {slice_left} != {slice_right}"
+
+
+def test_slice_z_height_inequality():
+    """Test slice inequality in z_height."""
+    slice_left = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+            (0.0, 0.4, 0.5),
+            (-0.4, 0.0, 0.5),
+            (0.0, -0.4, 0.5),
+        ],
+        z_height=0.5,
+    )
+    slice_right = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+            (0.0, 0.4, 0.5),
+            (-0.4, 0.0, 0.5),
+            (0.0, -0.4, 0.5),
+        ],
+        z_height=0.2,
+    )
+    assert slice_left != slice_right, f"Expect {slice_left} != {slice_right}"
+
+
+def test_slice_vertices_equality():
+    """Test slice equality method."""
+    slice_left = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+            (0.0, 0.4, 0.5),
+            (-0.4, 0.0, 0.5),
+            (0.0, -0.4, 0.5),
+        ],
+        z_height=0.5,
+    )
+    slice_right = Slice(
+        vertices=[
+            (0.4, 0.0, 0.5),
+            (0.0, 0.4, 0.5),
+            (-0.4, 0.0, 0.5),
+            (0.0, -0.4, 0.5),
+        ],
+        z_height=0.5,
+    )
+    assert slice_left == slice_right, f"Expect {slice_left} == {slice_right}"

--- a/tests/domain/test_slice.py
+++ b/tests/domain/test_slice.py
@@ -1,0 +1,16 @@
+""" test the Slice class. """
+
+from thicker.domain.slice import Slice
+
+
+def test_slice_initialization():
+    """
+    Test that a Slice object initializes correctly with vertices and z_height.
+    """
+    vertices = [(0.5, 0.2, 0.5), (0.4, -0.1, 0.5), (0.6, 0.1, 0.5)]
+    z_height = 0.5
+
+    slice_obj = Slice(vertices=vertices, z_height=z_height)
+
+    assert slice_obj.vertices == vertices
+    assert slice_obj.z_height == z_height

--- a/tests/domain/test_slice.py
+++ b/tests/domain/test_slice.py
@@ -1,5 +1,6 @@
 """ test the Slice class. """
 
+
 from thicker.domain.slice import Slice
 
 
@@ -84,3 +85,61 @@ def test_slice_collinear_vertices():
     assert (
         slice_obj.centroid() == expected_centroid
     ), f"Expected centroid {expected_centroid}, got {slice_obj.centroid()}"
+
+
+def test_slice_repr_no_vertices():
+    """
+    Test the __repr__ method when the Slice has no vertices.
+    """
+    slice_obj = Slice(vertices=[], z_height=1.0)
+
+    expected = "Slice(z_height=1.00, num_vertices=0, vertices=[])"
+    assert repr(slice_obj) == expected, f"Unexpected repr: {repr(slice_obj)}"
+
+
+def test_slice_repr_few_vertices():
+    """
+    Test the __repr__ method when the Slice has fewer than 3 vertices.
+    """
+    vertices = [(1.0, 2.0, 0.0), (0.5, 1.5, 0.5)]
+    slice_obj = Slice(vertices=vertices, z_height=0.5)
+
+    expected = (
+        "Slice(z_height=0.50, num_vertices=2, "
+        "vertices=[(1.0, 2.0, 0.0), (0.5, 1.5, 0.5)])"
+    )
+    assert repr(slice_obj) == expected, f"Unexpected repr: {repr(slice_obj)}"
+
+
+def test_slice_repr_exactly_three_vertices():
+    """
+    Test the __repr__ method when the Slice has exactly 3 vertices.
+    """
+    vertices = [(1.0, 2.0, 0.0), (0.5, 1.5, 0.5), (0.7, 1.8, 1.0)]
+    slice_obj = Slice(vertices=vertices, z_height=0.5)
+
+    expected = (
+        "Slice(z_height=0.50, num_vertices=3, "
+        "vertices=[(1.0, 2.0, 0.0), (0.5, 1.5, 0.5), (0.7, 1.8, 1.0)])"
+    )
+    assert repr(slice_obj) == expected, f"Unexpected repr: {repr(slice_obj)}"
+
+
+def test_slice_repr_more_than_three_vertices():
+    """
+    Test the __repr__ method when the Slice has more than 3 vertices.
+    """
+    vertices = [
+        (1.0, 2.0, 0.0),
+        (0.5, 1.5, 0.5),
+        (0.7, 1.8, 1.0),
+        (1.2, 2.3, 1.5),
+        (0.9, 1.6, 2.0),
+    ]
+    slice_obj = Slice(vertices=vertices, z_height=1.0)
+
+    expected = (
+        "Slice(z_height=1.00, num_vertices=5, "
+        "vertices=[(1.0, 2.0, 0.0), (0.5, 1.5, 0.5), (0.7, 1.8, 1.0)], ...)"
+    )
+    assert repr(slice_obj) == expected, f"Unexpected repr: {repr(slice_obj)}"

--- a/thicker/domain/cross_section_analysis.py
+++ b/thicker/domain/cross_section_analysis.py
@@ -38,7 +38,7 @@ def detect_narrow_cross_sections(mesh: Mesh, threshold: float = 0.5) -> list[Sli
             continue  # Skip empty slices
 
         # Calculate the max distance from the z-axis
-        max_radius = max((x**2 + y**2) ** 0.5 for x, y, _ in slice_vertices)
+        max_radius = max((x ** 2 + y ** 2) ** 0.5 for x, y, _ in slice_vertices)
 
         # Check if the radius is below the threshold
         if max_radius < threshold:

--- a/thicker/domain/cross_section_analysis.py
+++ b/thicker/domain/cross_section_analysis.py
@@ -1,9 +1,10 @@
-""" Cross-section analysis of meshes. """
+"""Cross-section analysis of meshes."""
 
 from thicker.domain.mesh import Mesh
+from thicker.domain.slice import Slice
 
 
-def detect_narrow_cross_sections(mesh: Mesh, threshold: float = 0.5) -> list[float]:
+def detect_narrow_cross_sections(mesh: Mesh, threshold: float = 0.5) -> list[Slice]:
     """
     Detect narrow cross-sections in a given mesh.
 
@@ -12,7 +13,7 @@ def detect_narrow_cross_sections(mesh: Mesh, threshold: float = 0.5) -> list[flo
         threshold: The minimum allowable radius for a cross-section.
 
     Returns:
-        A list of z-heights where the cross-section radius is below the threshold.
+        A list of Slices where the cross-section radius is below the threshold.
     """
     narrow_sections = []
     z_values = [z for _, _, z in mesh.vertices]
@@ -30,17 +31,17 @@ def detect_narrow_cross_sections(mesh: Mesh, threshold: float = 0.5) -> list[flo
 
         # Get vertices in this slice
         slice_vertices = [
-            (x, y) for x, y, z in mesh.vertices if slice_z_min <= z < slice_z_max
+            (x, y, z) for x, y, z in mesh.vertices if slice_z_min <= z < slice_z_max
         ]
 
         if not slice_vertices:
             continue  # Skip empty slices
 
         # Calculate the max distance from the z-axis
-        max_radius = max((x ** 2 + y ** 2) ** 0.5 for x, y in slice_vertices)
+        max_radius = max((x**2 + y**2) ** 0.5 for x, y, _ in slice_vertices)
 
         # Check if the radius is below the threshold
         if max_radius < threshold:
-            narrow_sections.append(slice_z_min)
+            narrow_sections.append(Slice(slice_vertices, slice_z_min))
 
     return narrow_sections

--- a/thicker/domain/cross_section_thickening.py
+++ b/thicker/domain/cross_section_thickening.py
@@ -1,11 +1,15 @@
-""" Thicken narrow cross-sections. """
+"""Thicken narrow cross-sections."""
 
 import math
+from typing import Tuple
 
 from thicker.domain.mesh import Mesh
+from thicker.domain.slice import Slice
 
 
-def thicken_cross_section(mesh: Mesh, narrow_sections, offset: float) -> Mesh:
+def thicken_cross_section(
+    mesh: Mesh, narrow_sections: list[Slice], offset: float
+) -> Mesh:
     threshold = 1.0
     thickener = CrossSectionThickener(threshold, offset)
     thickened_mesh = thickener.thicken(mesh, narrow_sections)
@@ -18,28 +22,80 @@ class CrossSectionThickener:
         self.threshold = threshold
         self.offset = offset
 
-    def thicken(self, mesh: Mesh, narrow_sections: list[float]) -> Mesh:
+    def thicken_vertex(
+        self,
+        vertex: Tuple[float, float, float],
+        centroid: Tuple[float, float],
+    ) -> Tuple[float, float, float]:
         """
-        Thicken the narrow cross sections of the mesh.
+        Thicken a vertex away from the centroid.
+
+        :param vertex: The original vertex in a narrow cross-section.
+        :param centroid: The centroid in the narrow cross-section to move away from.
+
+        :return: The thickened vertex, moved away from the centroid.
+
+        Calculate the vector from the centroid to the vertex.
+        Scale this vector outward by the offset.
+            𝑣_thickened = 𝑣_original + (𝑣_original - centroid)
+                / abs((𝑣_original - centroid) * offset
+        Equivalent maths:
+            𝑣_thickened = 𝑣_original + math.copysign(offset, (𝑣_original - centroid))
+        """
+        if math.isclose(vertex[0], centroid[0]):
+            delta_x = 0.0
+        else:
+            delta_x = math.copysign(self.offset, vertex[0] - centroid[0])
+
+        if math.isclose(vertex[1], centroid[1]):
+            delta_y = 0.0
+        else:
+            delta_y = math.copysign(self.offset, vertex[1] - centroid[1])
+
+        new_vertex = (
+            vertex[0] + delta_x,
+            vertex[1] + delta_y,
+            vertex[2],  # No thickening in z-direction
+        )
+        return new_vertex
+
+    def thicken(self, mesh: Mesh, narrow_sections: list[Slice]) -> Mesh:
+        """
+        Thicken the narrow cross-sections of the mesh.
 
         Args:
             mesh: The original mesh to be thickened.
-            narrow_sections: A list of z-heights where narrow cross sections
+            narrow_sections: A list of Slices where narrow cross-sections
                 were detected.
 
         Returns:
-            A new Mesh object with thickened cross sections.
+            A new Mesh object with thickened cross-sections.
         """
         new_vertices = []
+        slice_vertices = []
+        for narrow_section in narrow_sections:
+            for vertex in narrow_section.vertices:
+                slice_vertices.append(vertex)
+
         for x, y, z in mesh.vertices:
-            # Adjust vertices at detected narrow sections
-            if any(math.isclose(z, height, abs_tol=0.01) for height in narrow_sections):
-                distance = (x ** 2 + y ** 2) ** 0.5
-                factor = (distance + self.offset) / distance
-                new_x = x * factor
-                new_y = y * factor
-                new_vertices.append((new_x, new_y, z))
+            if (x, y, z) in slice_vertices:
+                new_vertex = self.get_thickened_vertex(x, y, z, narrow_sections)
+                new_vertices.append(new_vertex)
             else:
                 new_vertices.append((x, y, z))
-
         return Mesh(vertices=new_vertices, faces=mesh.faces)
+
+    def get_thickened_vertex(
+        self, x: float, y: float, z: float, narrow_sections: list[Slice]
+    ) -> Tuple[float, float, float]:
+        """ Adjust vertices at detected narrow sections. """
+        for narrow_slice in narrow_sections:
+            if (x, y, z) in narrow_slice.vertices:
+                # Thicken according to the slice centroid
+                # Move x and y radially from the slice centroid
+                slice_centroid = narrow_slice.centroid()
+                new_vertex = self.thicken_vertex(
+                    vertex=(x, y, z),
+                    centroid=slice_centroid,
+                )
+                return new_vertex

--- a/thicker/domain/slice.py
+++ b/thicker/domain/slice.py
@@ -30,3 +30,18 @@ class Slice:
         centroid_y = sum(y_coords) / len(y_coords)
 
         return (centroid_x, centroid_y)
+
+    def __repr__(self) -> str:
+        num_vertices = len(self.vertices)
+        if num_vertices == 0:
+            vertices_preview = "[]"
+        elif num_vertices <= 3:
+            vertices_preview = f"{self.vertices}"
+        else:
+            vertices_preview = f"{self.vertices[:3]}, ..."
+
+        return (
+            f"Slice(z_height={self.z_height:.2f}, "
+            f"num_vertices={num_vertices}, "
+            f"vertices={vertices_preview})"
+        )

--- a/thicker/domain/slice.py
+++ b/thicker/domain/slice.py
@@ -1,0 +1,13 @@
+""" The Slice class  - a set of vertices in a height range. """
+
+class Slice:
+    def __init__(self, vertices, z_height):
+        """
+        Initialize a Slice object.
+
+        Args:
+            vertices (list of tuples): List of (x, y, z) vertices in the slice.
+            z_height (float): The z-height at which this slice was taken.
+        """
+        self.vertices = vertices
+        self.z_height = z_height

--- a/thicker/domain/slice.py
+++ b/thicker/domain/slice.py
@@ -1,5 +1,6 @@
 """ The Slice class  - a set of vertices in a height range. """
 
+
 class Slice:
     def __init__(self, vertices, z_height):
         """
@@ -11,3 +12,21 @@ class Slice:
         """
         self.vertices = vertices
         self.z_height = z_height
+
+    def centroid(self):
+        """
+        Calculate the centroid of the slice in the x-y plane.
+
+        Returns:
+            tuple: The (x, y) coordinates of the centroid.
+        """
+        if not self.vertices:
+            return (0.0, 0.0)
+
+        x_coords = [v[0] for v in self.vertices]
+        y_coords = [v[1] for v in self.vertices]
+
+        centroid_x = sum(x_coords) / len(x_coords)
+        centroid_y = sum(y_coords) / len(y_coords)
+
+        return (centroid_x, centroid_y)

--- a/thicker/domain/slice.py
+++ b/thicker/domain/slice.py
@@ -1,4 +1,4 @@
-""" The Slice class  - a set of vertices in a height range. """
+"""The Slice class  - a set of vertices in a height range."""
 
 
 class Slice:
@@ -30,6 +30,14 @@ class Slice:
         centroid_y = sum(y_coords) / len(y_coords)
 
         return (centroid_x, centroid_y)
+
+    def __eq__(self, other):
+        """Overrides the default implementation"""
+        if isinstance(other, Slice):
+            return (self.vertices == other.vertices) and (
+                self.z_height == other.z_height
+            )
+        return False
 
     def __repr__(self) -> str:
         num_vertices = len(self.vertices)

--- a/thicker/domain/slice.py
+++ b/thicker/domain/slice.py
@@ -1,5 +1,7 @@
 """The Slice class  - a set of vertices in a height range."""
 
+from typing import Tuple
+
 
 class Slice:
     def __init__(self, vertices, z_height):
@@ -13,7 +15,7 @@ class Slice:
         self.vertices = vertices
         self.z_height = z_height
 
-    def centroid(self):
+    def centroid(self) -> Tuple[float, float]:
         """
         Calculate the centroid of the slice in the x-y plane.
 
@@ -21,15 +23,15 @@ class Slice:
             tuple: The (x, y) coordinates of the centroid.
         """
         if not self.vertices:
-            return (0.0, 0.0)
+            return 0.0, 0.0
 
-        x_coords = [v[0] for v in self.vertices]
-        y_coords = [v[1] for v in self.vertices]
+        x_coordinates = [v[0] for v in self.vertices]
+        y_coordinates = [v[1] for v in self.vertices]
 
-        centroid_x = sum(x_coords) / len(x_coords)
-        centroid_y = sum(y_coords) / len(y_coords)
+        centroid_x = sum(x_coordinates) / len(x_coordinates)
+        centroid_y = sum(y_coordinates) / len(y_coordinates)
 
-        return (centroid_x, centroid_y)
+        return centroid_x, centroid_y
 
     def __eq__(self, other):
         """Overrides the default implementation"""


### PR DESCRIPTION
Allow narrow cross sections, as slices, to  have a centroid off of the z-axis

## Summary by Sourcery

Implement centroid-based thickening for narrow cross-sections. Thickening is now based on the centroid of each slice, improving accuracy for offset features.

New Features:
- Thickening of narrow cross-sections is now based on the centroid of each slice, rather than the z-axis. This improves accuracy for offset features like arms and legs.

Tests:
- Added tests for the new centroid-based thickening logic, including cases with offset cross-sections.