### PR TITLE
Add uv lock file check to pre-commit routine.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,13 @@ repos:
       - id: ruff
         args: ["--fix"]
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: "0.5.14"
+    hooks:
+      - id: uv-lock
+        name: check uv lock file consistency
+        args: ["--locked"]
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: "v0.43.0"
     hooks:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add `uv-lock` hook to the pre-commit config.